### PR TITLE
Fix quotes and lastKnownFileType

### DIFF
--- a/lib/pbxFile.js
+++ b/lib/pbxFile.js
@@ -6,6 +6,7 @@ var path = require('path'),
     DYLIB_EXTENSION = /[.]dylib$/, DYLIB = '"compiled.mach-o.dylib"',
     FRAMEWORK_EXTENSION = /[.]framework/, FRAMEWORK = 'wrapper.framework',
     ARCHIVE_EXTENSION = /[.]a$/, ARCHIVE = 'archive.ar',
+    PNG_EXTENSION = /[.]png/, PNG_IMAGE = "image.png",
     DEFAULT_SOURCE_TREE = '"<group>"',
     DEFAULT_FILE_ENCODING = 4;
 
@@ -30,13 +31,16 @@ function detectLastType(path) {
 
     if (ARCHIVE_EXTENSION.test(path))
         return ARCHIVE;
-
+        
+    if (PNG_EXTENSION.test(path))
+        return PNG_IMAGE;
+        
     // dunno
     return 'unknown';
 }
 
 function fileEncoding(file) {
-    if (file.lastType != BUNDLE && !file.customFramework) {
+    if (file.lastType != BUNDLE && file.lastType !== PNG_IMAGE &&  !file.customFramework) {
         return DEFAULT_FILE_ENCODING;
     }
 }

--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -709,9 +709,18 @@ function pbxFileReferenceObj(file) {
 
     obj.isa = 'PBXFileReference';
     obj.lastKnownFileType = file.lastType;
+    obj.name = file.basename;
+    obj.path = file.path;
     
-    obj.name = "\"" + file.basename + "\"";
-    obj.path = "\"" + file.path + "\"";
+    if(obj.name.indexOf("\"") !== -1) {
+        obj.name = obj.name.replace(/\"/g, "\\\"");
+        obj.path = obj.path.replace(/\"/g, "\\\"");
+    }
+    
+    if(!file.basename.match(/^[a-zA-Z0-9_\.\$]+\.[a-zA-Z]+$/)) {
+         obj.name = "\"" + obj.name + "\"";
+    	 obj.path = "\"" + obj.path + "\"";
+    }
     
     obj.sourceTree = file.sourceTree;
 


### PR DESCRIPTION
##### Problem1 - Quotes

Quotes are added every time when pbxFileReferenceObj function is called. But we need them only when the file contains special characters. If the file doesn't contain special characters and `removeResourceFile` function is called, the resource was successfully removed from `pbxBuildFileSection`. But the file reference is not removed from `pbxFileReferenceSection`. This happens because the reference in `pbxproject` file doesn't contain quotes but we add the quotes and do incorrect comparison.
##### Problem2 - Unknown lastKnownFileType

 `addResourceFile` function sets `lastKnownFileType` property of file to `unknown` in `PBXFileReference` section. This PR fixes the type only .png image is added as resource.
