### PR TITLE
Fix path/name quotation

### DIFF
--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -8,7 +8,8 @@ var util = require('util'),
     pbxFile = require('./pbxFile'),
     fs = require('fs'),
     parser = require('./parser/pbxproj'),
-    COMMENT_KEY = /_comment$/
+    COMMENT_KEY = /_comment$/,
+    NO_SPECIAL_SYMBOLS = /^[a-zA-Z0-9_\.\$]+\.[a-zA-Z]+$/;
 
 function pbxProject(filename) {
     if (!(this instanceof pbxProject))
@@ -717,8 +718,11 @@ function pbxFileReferenceObj(file) {
         obj.path = obj.path.replace(/\"/g, "\\\"");
     }
     
-    if(!file.basename.match(/^[a-zA-Z0-9_\.\$]+\.[a-zA-Z]+$/)) {
+    if(!file.basename.match(NO_SPECIAL_SYMBOLS)) {
          obj.name = "\"" + obj.name + "\"";
+    }
+    
+    if(!file.path.match(NO_SPECIAL_SYMBOLS)) {
     	 obj.path = "\"" + obj.path + "\"";
     }
     

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "node-uuid":"1.3.3"
   },
   "devDependencies": {
-    "nodeunit":"0.6.4"
+    "nodeunit":"0.9.0"
   },
   "scripts": {
     "test": "node_modules/.bin/nodeunit test/parser test"

--- a/test/pbxProject.js
+++ b/test/pbxProject.js
@@ -202,3 +202,103 @@ exports['hasFile'] = {
         test.done()
     }
 }
+
+exports['addToPbxFileReferenceSection'] = {
+    'should not quote name when no special characters present in basename': function (test) {
+        var newProj = new pbx('.');
+            newProj.hash = jsonProject,
+            file = { 
+                uuid: newProj.generateUuid(), 
+                fileRef: newProj.generateUuid(), 
+                isa: 'PBXFileReference', 
+                explicitFileType: 'wrapper.application', 
+                includeInIndex: 0, 
+                basename: "SomeFile.m", 
+                path: "SomePath.m", 
+                sourceTree: 'BUILT_PRODUCTS_DIR' 
+            },
+            fileRefSection = newProj.pbxFileReferenceSection();
+
+        newProj.addToPbxFileReferenceSection(file);
+        test.equal(fileRefSection[file.fileRef].name, "SomeFile.m");
+        test.done();
+    },
+    'should quote name when special characters present in basename': function (test) {
+        var newProj = new pbx('.');
+            newProj.hash = jsonProject,
+            file = { 
+                uuid: newProj.generateUuid(), 
+                fileRef: newProj.generateUuid(), 
+                isa: 'PBXFileReference', 
+                explicitFileType: 'wrapper.application', 
+                includeInIndex: 0, 
+                basename: "Some File.m", 
+                path: "SomePath.m", 
+                sourceTree: 'BUILT_PRODUCTS_DIR' 
+            },
+            fileRefSection = newProj.pbxFileReferenceSection();
+
+        newProj.addToPbxFileReferenceSection(file);
+        test.equal(fileRefSection[file.fileRef].name, '"Some File.m"');
+        test.done();
+    },
+    'should not quote path when no special characters present in path': function (test) {
+        var newProj = new pbx('.');
+            newProj.hash = jsonProject,
+            file = { 
+                uuid: newProj.generateUuid(), 
+                fileRef: newProj.generateUuid(), 
+                isa: 'PBXFileReference', 
+                explicitFileType: 'wrapper.application', 
+                includeInIndex: 0, 
+                basename: "SomeFile.m", 
+                path: "SomePath.m", 
+                sourceTree: 'BUILT_PRODUCTS_DIR' 
+            },
+            fileRefSection = newProj.pbxFileReferenceSection();
+
+        newProj.addToPbxFileReferenceSection(file);
+        test.equal(fileRefSection[file.fileRef].path, "SomePath.m");
+        test.done();
+    },
+    'should quote path when special characters present in path': function (test) {
+        var newProj = new pbx('.');
+            newProj.hash = jsonProject,
+            file = { 
+                uuid: newProj.generateUuid(), 
+                fileRef: newProj.generateUuid(), 
+                isa: 'PBXFileReference', 
+                explicitFileType: 'wrapper.application', 
+                includeInIndex: 0, 
+                basename: "SomeFile.m", 
+                path: "SomeFolder/Some Path.m", 
+                sourceTree: 'BUILT_PRODUCTS_DIR' 
+            },
+            fileRefSection = newProj.pbxFileReferenceSection();
+
+        newProj.addToPbxFileReferenceSection(file);
+        test.equal(fileRefSection[file.fileRef].path, '"SomeFolder/Some Path.m"');
+        test.done();
+    },
+    'should quote path and name when special characters present in path and basename': function (test) {
+        var newProj = new pbx('.');
+            newProj.hash = jsonProject,
+            file = { 
+                uuid: newProj.generateUuid(), 
+                fileRef: newProj.generateUuid(), 
+                isa: 'PBXFileReference', 
+                explicitFileType: 'wrapper.application', 
+                includeInIndex: 0, 
+                basename: "Some File.m", 
+                path: "SomeFolder/Some Path.m", 
+                sourceTree: 'BUILT_PRODUCTS_DIR' 
+            },
+            fileRefSection = newProj.pbxFileReferenceSection();
+
+        newProj.addToPbxFileReferenceSection(file);
+        test.equal(fileRefSection[file.fileRef].name, '"Some File.m"');
+        test.equal(fileRefSection[file.fileRef].path, '"SomeFolder/Some Path.m"');
+        test.done();
+    }
+}
+


### PR DESCRIPTION
Those properties should be surrounded by quotation marks based on appearance of special characters in path and basename properties respectively.
They are independent of one another.
Includes unit tests as well as a newer nodeunit version as a dev dependency.
Ping @Fatme 
