### PR TITLE
Implement pbxTargetByName and pbxItemByComment

### DIFF
--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -445,16 +445,24 @@ pbxProject.prototype.pbxFileReferenceSection = function () {
 }
 
 pbxProject.prototype.pbxGroupByName = function (name) {
-    var groups = this.hash.project.objects['PBXGroup'],
-        key, groupKey;
+    return this.pbxItemByComment(name, 'PBXGroup');    
+}
 
-    for (key in groups) {
+pbxProject.prototype.pbxTargetByName = function (name) {
+    return this.pbxItemByComment(name, 'PBXNativeTarget');
+}
+
+pbxProject.prototype.pbxItemByComment = function (name, pbxSectionName) {
+    var section = this.hash.project.objects[pbxSectionName],
+        key, itemKey;
+
+    for (key in section) {
         // only look for comments
         if (!COMMENT_KEY.test(key)) continue;
 
-        if (groups[key] == name) {
-            groupKey = key.split(COMMENT_KEY)[0];
-            return groups[groupKey];
+        if (section[key] == name) {
+            itemKey = key.split(COMMENT_KEY)[0];
+            return section[itemKey];
         }
     }
 

--- a/test/pbxItemByComment.js
+++ b/test/pbxItemByComment.js
@@ -1,0 +1,50 @@
+var fullProject = require('./fixtures/full-project')
+    fullProjectStr = JSON.stringify(fullProject),
+    pbx = require('../lib/pbxProject'),
+    proj = new pbx('.');
+
+function cleanHash() {
+    return JSON.parse(fullProjectStr);
+}
+
+exports.setUp = function (callback) {
+    proj.hash = cleanHash();
+    callback();
+}
+
+exports.pbxItemByComment = {
+    'should return PBXTargetDependency': function (test) {
+        var pbxItem = proj.pbxItemByComment('PBXTargetDependency', 'PBXTargetDependency');
+
+        test.ok(pbxItem);
+        test.equals(pbxItem.isa, 'PBXTargetDependency');
+        test.done()
+    },
+    'should return PBXContainerItemProxy': function (test) {
+        var pbxItem = proj.pbxItemByComment('libPhoneGap.a', 'PBXReferenceProxy');
+        
+        test.ok(pbxItem);
+        test.equals(pbxItem.isa, 'PBXReferenceProxy');
+        test.done()
+    },
+    'should return PBXResourcesBuildPhase': function (test) {
+        var pbxItem = proj.pbxItemByComment('Resources', 'PBXResourcesBuildPhase');
+        
+        test.ok(pbxItem);
+        test.equals(pbxItem.isa, 'PBXResourcesBuildPhase');
+        test.done()
+    },
+    'should return PBXShellScriptBuildPhase': function (test) {
+        var pbxItem = proj.pbxItemByComment('Touch www folder', 'PBXShellScriptBuildPhase');
+        
+        test.ok(pbxItem);
+        test.equals(pbxItem.isa, 'PBXShellScriptBuildPhase');
+        test.done()
+    },
+    'should return null when PBXNativeTarget not found': function (test) {
+        var pbxItem = proj.pbxItemByComment('Invalid', 'PBXTargetDependency');
+        
+        test.equal(pbxItem, null);
+        test.done()
+    }
+}

--- a/test/pbxTargetByName.js
+++ b/test/pbxTargetByName.js
@@ -1,0 +1,29 @@
+var fullProject = require('./fixtures/full-project')
+    fullProjectStr = JSON.stringify(fullProject),
+    pbx = require('../lib/pbxProject'),
+    proj = new pbx('.');
+
+function cleanHash() {
+    return JSON.parse(fullProjectStr);
+}
+
+exports.setUp = function (callback) {
+    proj.hash = cleanHash();
+    callback();
+}
+
+exports.pbxTargetByName = {
+    'should return PBXNativeTarget': function (test) {
+        var pbxTarget = proj.pbxTargetByName('KitchenSinktablet');
+        
+        test.ok(pbxTarget);
+        test.equals(pbxTarget.isa, 'PBXNativeTarget');
+        test.done()
+    },
+    'should return null when PBXNativeTarget not found': function (test) {
+        var pbxTarget = proj.pbxTargetByName('Invalid');
+        
+        test.equal(pbxTarget, null);
+        test.done()
+    }
+}


### PR DESCRIPTION
Includes a bit of refactoring and extracting common logic between pbxGroupByName and pbxTargetByName into the more powerful function pbxItemByComment.

This is a handy way of searching for things in the PBXProject file.
Ping @Fatme 
