### PR TITLE
Fix file references inside .pbxproject

### DIFF
--- a/lib/pbxProject.js
+++ b/lib/pbxProject.js
@@ -927,11 +927,7 @@ pbxProject.prototype.addToLibrarySearchPaths = function (file) {
             buildSettings['LIBRARY_SEARCH_PATHS'] = [INHERITED];
         }
 
-        if (typeof file === 'string') {
-            buildSettings['LIBRARY_SEARCH_PATHS'].push(file);
-        } else {
-            buildSettings['LIBRARY_SEARCH_PATHS'].push(searchPathForFile(file, this));
-        }
+        buildSettings['LIBRARY_SEARCH_PATHS'].push(searchPathForFile(file, this));
     }
 }
 
@@ -940,7 +936,7 @@ pbxProject.prototype.removeFromHeaderSearchPaths = function (file) {
         INHERITED = '"$(inherited)"',
         SEARCH_PATHS = 'HEADER_SEARCH_PATHS',
         config, buildSettings, searchPaths;
-        var new_path = typeof file === 'string' ? file : searchPathForFile(file, this);
+        var new_path = searchPathForFile(file, this);
 
     for (config in configurations) {
         buildSettings = configurations[config].buildSettings;
@@ -976,11 +972,7 @@ pbxProject.prototype.addToHeaderSearchPaths = function (file) {
             buildSettings['HEADER_SEARCH_PATHS'] = [INHERITED];
         }
 
-        if (typeof file === 'string') {
-            buildSettings['HEADER_SEARCH_PATHS'].push(file);
-        } else {
-            buildSettings['HEADER_SEARCH_PATHS'].push(searchPathForFile(file, this));
-        }
+        buildSettings['HEADER_SEARCH_PATHS'].push(searchPathForFile(file, this));
     }
 }
 
@@ -1130,8 +1122,27 @@ function correctForPath(file, project, group) {
 }
 
 function searchPathForFile(file, proj) {
+    const getPathString = (filePath) => {
+        return `"\\"${filePath}\\""`;
+    }
+
+    const getRelativePathString = (filePath) => {
+        return getPathString(`$(SRCROOT)/${filePath}`);
+    }
+
+    if (typeof file === 'string') {
+        const relativeFilePath = file;
+
+        if ($path.isAbsolute(file)) {
+            const srcRoot = $path.dirname($path.dirname(proj.filepath));
+            relativeFilePath = $path.relative(srcRoot, file);
+        }
+
+        return getRelativePathString(relativeFilePath);
+    }
+
     if (file.relativePath) {
-        return '"\$(SRCROOT)/' + file.relativePath + '\"';
+        return getRelativePathString(file.relativePath);
     }
 
     var plugins = proj.pbxGroupByName('Plugins'),
@@ -1145,11 +1156,11 @@ function searchPathForFile(file, proj) {
     }
 
     if (file.plugin && pluginsPath) {
-        return '"\\"$(SRCROOT)/' + unquote(pluginsPath) + '\\""';
+        return getRelativePathString(unquote(pluginsPath));
     } else if (file.customFramework && file.dirname) {
-        return '"\\"' + file.dirname + '\\""';
+        return getPathString(file.dirname);
     } else {
-        return '"\\"$(SRCROOT)/' + proj.productName + fileDir + '\\""';
+        return getRelativePathString(proj.productName + fileDir);
     }
 }
 


### PR DESCRIPTION
{N} CLI is not able to build a native project in case when the project name contains a space. In this case the filePaths inside HEADER_SEARCH_PATHS sections are not valid. Actually this PR fixes 2 problems.
The first is that the added filePath is full file path, so this PR changes this and makes the paths relative.
The second thing is that the filePath does not contain " ", so this PR adds "" around the filePath.

Steps to reproduce:
1. `tns create "my space app"`
2. Change the version of `tns-core-modules` to next
3. `tns build ios`